### PR TITLE
remove latest tag from push.

### DIFF
--- a/push.sh
+++ b/push.sh
@@ -13,9 +13,8 @@ image=docs
 
 mkdocs build
 
-docker build -t $registry/$image:$tag -t $registry/$image:latest .
+docker build -t $registry/$image:$tag .
 docker push $registry/$image:$tag
-docker push $registry/$image:latest
 
 JSON='{"image": "'"$registry/$image"'", "tag": "'"$tag"'"}'
 printf '%s' "$JSON"


### PR DESCRIPTION
This is to speed up deployment as latest tag is not used.