### PR TITLE
Nested exclusion example

### DIFF
--- a/docs/concepts/CLQL.md
+++ b/docs/concepts/CLQL.md
@@ -240,6 +240,8 @@ method:
           name == "nil"
 ```
 
+More examples of nested exclusion can be found [here](https://www.codelingo.io/docs/concepts/examples/#nested-exclusion).
+
 Note: Facts nested under multiple excludes still do not return results and cannot be [decorated.](https://www.codelingo.io/docs/concepts/actions/#action-function-decorators)
 
 <br />

--- a/docs/concepts/examples.md
+++ b/docs/concepts/examples.md
@@ -206,7 +206,7 @@ Thinking about this in the same way, we can read the above as:
  - Then of those thrown out, take back those with if statements 
  - Then of those taken back, throw out those with assignment statements
 
-So we end up with each function without a for loop - **and** - those with for loops but without child if statements - unless - those if statements contain assignment statements. You can see how it gets complicated to think of exclusion in this way as the number of exclude statements increases, and so the layer by layer approach can help clarify what is being expressed.
+So we end up with each function without a for loop - **and** - those with for loops but without child if statements - **unless** - those if statements contain assignment statements. You can see how it gets complicated to think of exclusion in this way as the number of exclude statements increases, and so the layer by layer approach can help clarify what is being expressed.
 
 As a sanity check, it helps to remember that as we move in descending order down the tree, each odd numbered exclusion can only decrease the number of results of its parent, and each even numbered exclusion can only increase the number of results it inherits from its parent exclusion.
 

--- a/docs/concepts/examples.md
+++ b/docs/concepts/examples.md
@@ -154,6 +154,64 @@ cs.element:
 
 The above query matches all C# elements that are not generated, whose declaration does not have an access modifier.
 
+## Nested Exclusion
+
+Nested exclusion can seem confusing initially, but it provides CLQL with a powerful way to capture complex patterns of code in very few lines, so it’s worth understanding. The following example will look at using nested exclusion to identify patterns in a Golang program but the logic is equivalent for all languages.
+
+A single exclusion like the one shown below can be read as - find all instances of X (the decorated fact) which do not have a child Y (whatever is being excluded). In this case, find all functions which do not contain assignment statements.
+
+```yaml
+@review comment:
+go.func_decl(depth = any):
+  exclude:
+    go.assign_stmt(depth = any)
+```
+
+But when it comes to nested exclusion it helps to think of beginning with a pile containing each instance of X (in this case a function), and then throwing out those instances of X which have Y (the assignment statement) as children.
+
+Now consider the following query:
+
+```yaml
+@review comment
+go.func_decl(depth = any):
+  exclude:
+    go.if_stmt(depth = any):
+      exclude:
+        go.assign_stmt(depth = any)
+```
+
+The logic of exclusion is executed later by layer, meaning the above query can be thought of as:
+
+ - Take all functions, then throw out those with if Statements
+ - Then of those thrown out, add back the ones with assignment statements
+
+So we end up with all of the functions that don’t have if statements - **and** - those which have if statements which contain assignment statements. In this way each exclusion can be thought of as overriding the authority of the one above it, because it provides an exception to its rule.
+
+Let’s add another exclude:
+
+```yaml
+@review comment
+go.func_decl(depth = any):
+  exclude:
+    go.for_loop(depth = any):
+      exclude:
+        go.if_stmt(depth = any):
+          exclude:
+            go.assign_stmt(depth = any)
+```
+
+Thinking about this in the same way, we can read the above as:
+
+ - Get all functions, then throw out all with for loops, 
+ - Then of those thrown out, take back those with if statements, 
+ - Then of those taken back, throw out those with assignment statements
+
+So we end up with each function without a for loop - **and** - those with for loops but without child if statements - unless - those if statements contain assignment statements. You can see how it gets complicated to think of exclusion in this way as the number of exclude statements increases, and so the layer by layer approach can help clarify what is being expressed.
+
+As a sanity check, it helps to remember that as we move in descending order down the tree, each odd numbered exclusion can only decrease the number of results of its parent, and each even numbered exclusion can only increase the number of results it inherits from its parent exclusion.
+
+This pattern can be repeated to arbitrary depth.
+
 
 # Runtime
 

--- a/docs/concepts/examples.md
+++ b/docs/concepts/examples.md
@@ -202,8 +202,8 @@ go.func_decl(depth = any):
 
 Thinking about this in the same way, we can read the above as:
 
- - Get all functions, then throw out all with for loops, 
- - Then of those thrown out, take back those with if statements, 
+ - Get all functions, then throw out all with for loops
+ - Then of those thrown out, take back those with if statements 
  - Then of those taken back, throw out those with assignment statements
 
 So we end up with each function without a for loop - **and** - those with for loops but without child if statements - unless - those if statements contain assignment statements. You can see how it gets complicated to think of exclusion in this way as the number of exclude statements increases, and so the layer by layer approach can help clarify what is being expressed.


### PR DESCRIPTION
Additional examples of nested exclude have been requested several times, this example shows how nested exclude statement alter the meaning of a query.