### PR TITLE
Create .github/CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+
+# Require Jesse or Ben to review PRs and approve changes to master for the docs.
+# See https://github.com/codelingo/docs/settings/branch_protection_rules/1003050
+/docs/  @waigani @mrcrowl


### PR DESCRIPTION
Requires PR reviews by Jesse or Ben for any content in the docs/ folder.